### PR TITLE
Fix specs atop Traject 2.3.4

### DIFF
--- a/lib/traject_plus/extraction.rb
+++ b/lib/traject_plus/extraction.rb
@@ -37,7 +37,8 @@ module TrajectPlus
       ['split', 'concat', 'prepend', 'gsub', 'encode', 'insert'].each do |method|
         define_method(method) do |values, *args|
           values.flat_map do |v|
-            v.public_send(method, *args)
+            # Cannot prepend to frozen string; use #dup to effectively unfreeze
+            v.dup.public_send(method, *args)
           end
         end
       end

--- a/lib/traject_plus/indexer/step.rb
+++ b/lib/traject_plus/indexer/step.rb
@@ -16,19 +16,13 @@ module TrajectPlus
         false
       end
 
-      def execute(context)
-        accumulator = super
-
-        add_accumulator_to_context!(accumulator, context)
-      end
-
       def add_accumulator_to_context!(accumulator, context)
         self.class.add_accumulator_to_context!(self, field_name, accumulator, context)
       end
 
       def self.add_accumulator_to_context!(field, field_name, accumulator, context)
-        accumulator.compact! unless context.settings[Traject::Indexer::ALLOW_NIL_VALUES]
-        return if accumulator.empty? and not (context.settings[Traject::Indexer::ALLOW_EMPTY_FIELDS])
+        accumulator.compact! unless context.settings[ALLOW_NIL_VALUES]
+        return if accumulator.empty? and not (context.settings[ALLOW_EMPTY_FIELDS])
 
         if field.single?
           context.output_hash[field_name] = accumulator.first if accumulator.length > 0
@@ -36,7 +30,7 @@ module TrajectPlus
           context.output_hash[field_name] ||= []
 
           existing_accumulator = context.output_hash[field_name].concat(accumulator)
-          existing_accumulator.uniq! unless context.settings[Traject::Indexer::ALLOW_DUPLICATE_VALUES]
+          existing_accumulator.uniq! unless context.settings[ALLOW_DUPLICATE_VALUES]
         end
       end
     end

--- a/traject_plus.gemspec
+++ b/traject_plus.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport'
   spec.add_dependency 'jsonpath'
-  spec.add_dependency 'traject'
+  spec.add_dependency 'traject', '~> 2.3', '>= 2.3.4'
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Duplicate value to "unfreeze" it, allowing the prepend transformation

Reflect changes made in Traject 2.3.4

The TrajectPlus team made the following commit in Traject which was released as version 2.3.4: traject/traject@892f263

With this change in Traject, TrajectPlus needs these changes to continue working.

Fixes https://github.com/sul-dlss-labs/rialto-etl/issues/4