### PR TITLE
Support Traject 3.0.0

### DIFF
--- a/traject_plus.gemspec
+++ b/traject_plus.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport'
   spec.add_dependency 'jsonpath'
-  spec.add_dependency 'traject', '~> 2.3', '>= 2.3.4'
+  spec.add_dependency 'traject', '~> 3.0'
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Note that this is a rather naïve commit to 1) use Traject 3.0.0, and 2) make tests pass. We might want to do further work on this branch to more fully support the changes in Traject 3, and eliminate any code in TrajectPlus that is duplicate of what is it in Traject 3. This commit makes no attempt to maintain backwards compatibility with past versions of TrajectPlus.

This is mostly for discussion purposes.