### PR TITLE
Deprecate our custom extract and transform arguments.

### DIFF
--- a/lib/traject_plus/extraction.rb
+++ b/lib/traject_plus/extraction.rb
@@ -4,6 +4,7 @@ require 'active_support/core_ext/object/blank'
 require 'deprecation'
 
 module TrajectPlus
+  # @deprecated because Traject 3 can do this for us.
   module Extraction
     def self.apply_extraction_options(result, options = {})
       TransformPipeline.new(options).transform(result)

--- a/lib/traject_plus/macros/csv.rb
+++ b/lib/traject_plus/macros/csv.rb
@@ -10,6 +10,9 @@ module TrajectPlus
         lambda do |row, accumulator, _context|
           return if row[header_or_index].to_s.empty?
           result = Array(row[header_or_index].to_s)
+          unless options.empty?
+            Deprecation.warn(self, "passing options to column is deprecated and will be removed in the next major release. Use the Traject 3 pipeline instead")
+          end
           result = TrajectPlus::Extraction.apply_extraction_options(result, options)
           accumulator.concat(result)
         end

--- a/lib/traject_plus/macros/json.rb
+++ b/lib/traject_plus/macros/json.rb
@@ -12,6 +12,9 @@ module TrajectPlus
         lambda do |json, accumulator, _context|
           result = Array(JsonPath.on(json, path))
           result = TrajectPlus::Extraction.apply_extraction_options(result, options)
+          unless options.empty?
+            Deprecation.warn(self, "passing options to extract_json is deprecated and will be removed in the next major release. Use the Traject 3 pipeline instead")
+          end
           accumulator.concat(result)
         end
       end

--- a/lib/traject_plus/macros/xml.rb
+++ b/lib/traject_plus/macros/xml.rb
@@ -10,6 +10,9 @@ module TrajectPlus
       def extract_xml(xpath, namespaces, options = {})
         lambda do |xml, accumulator, _context|
           result = xml.xpath(xpath, namespaces).map(&:text)
+          unless options.empty?
+            Deprecation.warn(self, "passing options to extract_xml is deprecated and will be removed in the next major release. Use the Traject 3 pipeline instead")
+          end
           result = TrajectPlus::Extraction.apply_extraction_options(result, options)
           accumulator.concat(result)
         end

--- a/spec/lib/traject_plus/macros_spec.rb
+++ b/spec/lib/traject_plus/macros_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe TrajectPlus::Macros do
 
   describe '#transform' do
     it 'runs values through a common transform pipeline' do
+      expect(Deprecation).to receive(:warn).twice
       indexer.instance_eval do
         to_field 'some_field', extract: accumulate { |record, *_| record[:value] }, transform: transform(split: '/', prepend: '-', upcase: true)
       end
@@ -61,6 +62,7 @@ RSpec.describe TrajectPlus::Macros do
   describe '#to_field' do
     context 'with extract and transform fields' do
       it 'runs both extract and transform' do
+        expect(Deprecation).to receive(:warn).twice
         indexer.instance_eval do
           to_field 'some_field', extract: accumulate { |record, *_| record[:value] }, transform: transform(split: '/', prepend: '-', upcase: true)
         end
@@ -72,7 +74,7 @@ RSpec.describe TrajectPlus::Macros do
     context 'with a list of procs' do
       it 'runs all procs' do
         indexer.instance_eval do
-          to_field 'some_field', accumulate { |record, *_| record[:value] }, transform(split: '/', prepend: '-', upcase: true), transform(append: '*')
+          to_field 'some_field', accumulate { |record, *_| record[:value] }, split('/'), prepend('-'), transform(&:upcase), append('*')
         end
 
         expect(indexer.map_record(value: 'a/b/c')).to include 'some_field' => ['-A*', '-B*', '-C*']


### PR DESCRIPTION
Traject 3 now handles multiple transformation arguments so there's no
need for TrajectPlus to maintain a separate way of doing this.