### PR TITLE
Change mechanism for extending Traject macros

### DIFF
--- a/lib/traject_plus/macros/fgdc.rb
+++ b/lib/traject_plus/macros/fgdc.rb
@@ -6,9 +6,7 @@ module TrajectPlus
     module FGDC
       NS = { fgdc: 'http://www.fgdc.gov/metadata/fgdc-std-001-1998.dtd' }.freeze
 
-      def self.extended(mod)
-        mod.extended Traject::Macros::NokogiriMacros
-      end
+      include Traject::Macros::NokogiriMacros
 
       # @param xpath [String] the xpath query expression
       def extract_fgdc(xpath)

--- a/lib/traject_plus/macros/mods.rb
+++ b/lib/traject_plus/macros/mods.rb
@@ -9,13 +9,11 @@ module TrajectPlus
              dc: 'http://purl.org/dc/elements/1.1/',
              xlink: 'http://www.w3.org/1999/xlink' }.freeze
 
-      def self.extended(mod)
-        mod.extended Traject::Macros::NokogiriMacros
-      end
+      include Traject::Macros::NokogiriMacros
 
       # @param xpath [String] the xpath query expression
       def extract_mods(xpath)
-        extract_xpath(xpath, NS)
+        extract_xpath(xpath, ns: NS)
       end
     end
   end

--- a/lib/traject_plus/macros/tei.rb
+++ b/lib/traject_plus/macros/tei.rb
@@ -5,9 +5,7 @@ module TrajectPlus
     module Tei
       NS = { tei: 'http://www.tei-c.org/ns/1.0' }.freeze
 
-      def self.extended(mod)
-        mod.extended Traject::Macros::NokogiriMacros
-      end
+      include Traject::Macros::NokogiriMacros
 
       # @param xpath [String] the xpath query expression
       def extract_tei(xpath)

--- a/spec/lib/traject_plus/macros_spec.rb
+++ b/spec/lib/traject_plus/macros_spec.rb
@@ -11,15 +11,25 @@ RSpec.describe TrajectPlus::Macros do
   end
 
   describe '#transform_values' do
-    let(:doc) { Nokogiri::XML('<xml><foo> bar </foo></xml>') }
+    let(:doc) do
+      Nokogiri::XML(
+        <<-XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <mods xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd" version="3.3">
+            <genre>bar</genre>
+          </mods>
+        XML
+      )
+    end
+
     context 'with lambdas with 2 and 3 arity' do
       it 'runs both' do
-        indexer.extend Traject::Macros::NokogiriMacros
+        indexer.extend TrajectPlus::Macros::Mods
         indexer.instance_eval do
           to_field 'some_field' do |_record, accumulator, context|
             accumulator << transform_values(
               context,
-              'wr_id' => [extract_xpath('//foo'), strip]
+              'wr_id' => [extract_xpath('//genre'), strip]
             )
           end
         end

--- a/spec/lib/traject_plus/macros_spec.rb
+++ b/spec/lib/traject_plus/macros_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe TrajectPlus::Macros do
@@ -29,12 +30,14 @@ RSpec.describe TrajectPlus::Macros do
           to_field 'some_field' do |_record, accumulator, context|
             accumulator << transform_values(
               context,
-              'wr_id' => [extract_xpath('//genre'), strip]
+              'wr_id' => [extract_xpath('//mods:genre', ns: TrajectPlus::Macros::Mods::NS), strip]
             )
           end
+          to_field 'other_field', extract_mods('/*/mods:genre')
         end
 
-        expect(indexer.map_record(doc)).to eq('some_field' => [{ 'wr_id' => ['bar'] }])
+        expect(indexer.map_record(doc)).to eq('some_field' => [{ 'wr_id' => ['bar'] }],
+                                              'other_field' => ['bar'])
       end
     end
   end


### PR DESCRIPTION
Fixes #33

Also includes:
* Tweak the macros spec such that it tests the mechanism of module inclusion
* Fix a (typo?) bug where the Mods module did not use the `ns:` kwarg when calling `extract_xpath`. This causes an `ArgumentError` in Traject.