### PR TITLE
Add csv as a dependency

### DIFF
--- a/traject_plus.gemspec
+++ b/traject_plus.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'jsonpath'
   spec.add_dependency 'traject', '~> 3.0'
   spec.add_dependency 'deprecation'
+  spec.add_dependency 'csv'
 
   spec.add_development_dependency "bundler", '>= 2.0'
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION


## Why was this change made?

it will no longer be part of the standard library in Ruby 3.4

## How was this change tested?



## Which documentation and/or configurations were updated?



